### PR TITLE
Fix paths / variables issues for Cygwin / Windows command prompt

### DIFF
--- a/distro/src/main/resources/bin/run.bat
+++ b/distro/src/main/resources/bin/run.bat
@@ -24,7 +24,7 @@ rem $Id$
 @if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
-  set "DIRNAME=%~dp0%"
+  set "DIRNAME=%~dp0%.."
 ) else (
   set DIRNAME=.\
 )
@@ -40,7 +40,7 @@ set HOST=localhost
 set PORT=31000
 
 set OUTPUTDIR=%DIRNAME%\results
-set CONFIG=%DIRNAME%\..\config\test.properties
+set CONFIG=%DIRNAME%\config\test.properties
 
 rem set USERNAME=
 rem set PASSWORD=
@@ -61,24 +61,24 @@ set RMODE=%2
 
 ) 
 
-ARGS=-Dscenario.file=%S_DIR%
-ARGS=%ARGS% -Dqueryset.artifacts.dir=%QUERYSETDIR%
-ARGS=%ARGS% -Dresult.mode=%RMODE%
-ARGS=%ARGS% -Doutput.dir=%OUTPUTDIR%
-ARGS=%ARGS% -Dconfig=%CONFIG%
-ARGS=%ARGS% -Dhost.name=%HOST%
-ARGS=%ARGS% -Dhost.port=%PORT%
+set ARGS=-Dscenario.file=%S_DIR%
+set ARGS=%ARGS% -Dqueryset.artifacts.dir=%QUERYSETDIR%
+set ARGS=%ARGS% -Dresult.mode=%RMODE%
+set ARGS=%ARGS% -Doutput.dir=%OUTPUTDIR%
+set ARGS=%ARGS% -Dconfig=%CONFIG%
+set ARGS=%ARGS% -Dhost.name=%HOST%
+set ARGS=%ARGS% -Dhost.port=%PORT%
 
 rem *** Uncomment to enable query plans ***
 rem ARGS=%ARGS% -Dbqt.query.plan=true
 
 
-ARGS=%ARGS% -Dexectimemin=%EXECTIMEMIN%
-ARGS=%ARGS% -Dexceedpercent=%EXCEEDPERCENT%
+set ARGS=%ARGS% -Dexectimemin=%EXECTIMEMIN%
+set ARGS=%ARGS% -Dexceedpercent=%EXCEEDPERCENT%
 
 rem If not set, the default to scenario or global properties
 if not "x%USERNAME%" == "x" (
-  set  ARGS=%ARGS -Dusername=%USERNAME%
+  set  ARGS=%ARGS% -Dusername=%USERNAME%
 )
 
 rem If not set, the default to scenario or global properties

--- a/distro/src/main/resources/bin/run.sh
+++ b/distro/src/main/resources/bin/run.sh
@@ -51,6 +51,13 @@ if [ -r "$RUN_CONF" ]; then
    . "$RUN_CONF"
 fi
 
+# Convert paths for Windows Java if Cygwin is used
+if [ "$(uname -o)" == "Cygwin" ]; then
+    SCENARIODIR=`cygpath -w ${SCENARIODIR}`
+    QUERYSETDIR=`cygpath -w ${QUERYSETDIR}`
+    OUTPUTDIR=`cygpath -w ${OUTPUTDIR}`
+fi
+
 echo "SCENARIODIR: ${SCENARIODIR}"
 #--------------------
 
@@ -181,6 +188,11 @@ fi
 
 
 CP="${ROOTDIR}:${ROOTDIR}/config/*:${ROOTDIR}/lib/*"
+
+# Convert classpath for Windows Java if Cygwin is used
+if [ "$(uname -o)" == "Cygwin" ]; then
+    CP=$(cygpath -pw $CP)
+fi
 
 LOGLEVEL=info
 


### PR DESCRIPTION
As I use Windows at work office, I need to have BQT working well with Windows. I use regularly Cygwin but I tried to fix also BAT script used by Windows command prompt.

Hope this helps

Jean-Pierre
